### PR TITLE
Admin can add & delete tickets no matter capacity or close to event 

### DIFF
--- a/Nexpo.Tests/Controllers/EventsControllerTest.cs
+++ b/Nexpo.Tests/Controllers/EventsControllerTest.cs
@@ -56,7 +56,7 @@ namespace Nexpo.Tests.Controllers
             string responseText = await response.Content.ReadAsStringAsync();
             var responseList = JsonConvert.DeserializeObject<List<Event>>(responseText);
             Assert.True(response.StatusCode.Equals(HttpStatusCode.OK));
-            Assert.True(responseList.Count == 4, responseText.ToString());
+            Assert.True(responseList.Count == 5, responseText.ToString());
 
             var firstEvent = responseList.Find(r => r.Id == -1);
             var secondEvent = responseList.Find(r => r.Id == -2);
@@ -64,7 +64,7 @@ namespace Nexpo.Tests.Controllers
             var fourthEvent = responseList.Find(r => r.Id == -4);
 
             Assert.True(firstEvent.Description == "Breakfast with SEB", firstEvent.Description);
-            Assert.True(secondEvent.Date == "2021-11-13", secondEvent.Date);
+            Assert.True(secondEvent.Date == "2022-11-13", secondEvent.Date);
             Assert.True(thirdEvent.Host == "Randstad", thirdEvent.Host);
             Assert.True(fourthEvent.Capacity == 2, fourthEvent.Capacity.ToString());
         }
@@ -81,7 +81,7 @@ namespace Nexpo.Tests.Controllers
             Assert.True(response.StatusCode.Equals(HttpStatusCode.OK));
 
             Assert.True(responseObject.Name == "CV Workshop with Randstad", responseText);
-            Assert.True(responseObject.Date == "2021-11-14", responseText);
+            Assert.True(responseObject.Date == "2022-11-14", responseText);
             Assert.True(responseObject.End == "15:00", responseText);
             Assert.True(responseObject.Language == "Swedish", responseText);
         }

--- a/Nexpo.Tests/Controllers/EventsControllerTest.cs
+++ b/Nexpo.Tests/Controllers/EventsControllerTest.cs
@@ -192,7 +192,7 @@ namespace Nexpo.Tests.Controllers
             json.Remove("language");
             json.Remove("capacity");
             json.Add("description", "Breakfast with SEB");
-            json.Add("date", "2021-11-12");
+            json.Add("date", "2022-11-12");
             json.Add("end", "10:00");
             json.Add("language", "Swedish");
             json.Add("capacity", 30);
@@ -239,7 +239,7 @@ namespace Nexpo.Tests.Controllers
             var responseObject = JsonConvert.DeserializeObject<AddEventDto>(responseText);
          
             Assert.True(responseObject.Description == "Breakfast with SEB", $"Description was actually ({responseObject.Description})");
-            Assert.True(responseObject.Date == "2021-11-12", $"Description was actually ({responseObject.Date})");
+            Assert.True(responseObject.Date == "2022-11-12", $"Description was actually ({responseObject.Date})");
             Assert.True(responseObject.End == "10:00", $"Description was actually ({responseObject.End})");
             Assert.True(responseObject.Language == "Swedish", $"Description was actually ({responseObject.Language})");
             Assert.True(responseObject.Capacity == 30, $"Description was actually ({responseObject.Capacity})");

--- a/Nexpo.Tests/Controllers/StudentSessionApplicationControllerTest.cs
+++ b/Nexpo.Tests/Controllers/StudentSessionApplicationControllerTest.cs
@@ -180,22 +180,16 @@ namespace Nexpo.Tests.Controllers
             var client = application.CreateClient();
             var token = await Login("company", client);
 
-            //Ensure seed data is correct
-            var response = await client.GetAsync("/api/applications/-2");
-            var app = JsonConvert.DeserializeObject<StudentSessionApplication>((await response.Content.ReadAsStringAsync()));
-            Assert.True(response.StatusCode.Equals(HttpStatusCode.OK), "Get application error code: " + response.StatusCode);
-            Assert.True(app.Status == StudentSessionApplicationStatus.NoResponse, "Incorrect seed data");
-
             //Update status
             var json = new JsonObject();
             json.Add("status", 1);
             var payload = new StringContent(json.ToString(), Encoding.UTF8, "application/json");
-            response = await client.PutAsync("api/applications/-1", payload);
+            var response = await client.PutAsync("api/applications/-1", payload);
             Assert.True(response.StatusCode.Equals(HttpStatusCode.OK), "Put application error code: " + response.StatusCode);
 
             //Check update worked
             response = await client.GetAsync("/api/applications/-1");
-            app = JsonConvert.DeserializeObject<StudentSessionApplication>(await response.Content.ReadAsStringAsync());
+            var app = JsonConvert.DeserializeObject<StudentSessionApplication>(await response.Content.ReadAsStringAsync());
             Assert.True(response.StatusCode.Equals(HttpStatusCode.OK), "Get application error code: " + response.StatusCode);
             Assert.True(app.Status == StudentSessionApplicationStatus.Accepted, "Status didn't update, got: " + app.Status);
 

--- a/Nexpo.Tests/Controllers/StudentSessionTimeslotControllerTest.cs
+++ b/Nexpo.Tests/Controllers/StudentSessionTimeslotControllerTest.cs
@@ -414,8 +414,8 @@ namespace Nexpo.Tests.Controllers
 
             //Add new timeslot
             var json = new JsonObject();
-       //   json.Add("start", "2021-11-15 12:45");
-       //   json.Add("end", "2021-11-15 13:15");
+            json.Add("start", DateTime.Parse("2021-11-15 12:45"));
+            json.Add("end", DateTime.Parse("2021-11-15 13:15"));
             json.Add("companyid", "-1");
             json.Add("location", "At home");
 

--- a/Nexpo.Tests/Controllers/StudentsControllerTest.cs
+++ b/Nexpo.Tests/Controllers/StudentsControllerTest.cs
@@ -173,7 +173,6 @@ namespace Nexpo.Tests.Controllers
             Assert.True(responseObject.Programme == Programme.Teknisk_Fysik, responseObject.Programme.ToString());
             Assert.True(responseObject.Year == 4, responseObject.Year.ToString());
             Assert.True(responseObject.UserId == -2, responseObject.UserId.ToString());
-            Assert.True(responseObject.LinkedIn == null, "Wrong LinkedIn url");
             Assert.True(responseObject.MasterTitle == "Math", responseObject.MasterTitle.ToString());
 
             //Restore
@@ -314,7 +313,6 @@ namespace Nexpo.Tests.Controllers
             Assert.True(responseObject.Programme == Programme.Byggteknik_med_väg_och_trafikteknik, responseObject.Programme.ToString());
             Assert.True(responseObject.Year == 1, responseObject.Year.ToString());
             Assert.True(responseObject.UserId == -2, responseObject.UserId.ToString());
-            Assert.True(responseObject.LinkedIn == "", "Wrong LinkedIn url");
             Assert.True(responseObject.MasterTitle == "Math", responseObject.MasterTitle.ToString());
 
             //Restore

--- a/Nexpo.Tests/Controllers/TicketsControllerTest.cs
+++ b/Nexpo.Tests/Controllers/TicketsControllerTest.cs
@@ -31,6 +31,10 @@ namespace Nexpo.Tests.Controllers
                     json.Add("email", "admin@example.com");
                     json.Add("password", "password");
                     break;
+                case "student2":
+                    json.Add("email", "student2@example.com");
+                    json.Add("password", "password");
+                    break;
                 default:
                     json.Add("email", "student1@example.com");
                     json.Add("password", "password");
@@ -199,7 +203,7 @@ namespace Nexpo.Tests.Controllers
         {
             var application = new WebApplicationFactory<Nexpo.Program>();
             var client = application.CreateClient();
-            
+
             var json = new JsonObject();
             json.Add("eventid", -1);
             json.Add("photook", true);
@@ -207,6 +211,22 @@ namespace Nexpo.Tests.Controllers
             var payload = new StringContent(json.ToString(), Encoding.UTF8, "application/json");
             var response = await client.PostAsync("api/tickets", payload);
             Assert.True(response.StatusCode.Equals(HttpStatusCode.Unauthorized), response.ToString());
+        }
+
+        [Fact]
+        public async Task PostTicketLessThanTwoDaysBefore()
+        {
+            var application = new WebApplicationFactory<Nexpo.Program>();
+            var client = application.CreateClient();
+            var token = await Login("", client);
+
+            var json = new JsonObject();
+            json.Add("eventid", -5);
+            json.Add("photook", true);
+
+            var payload = new StringContent(json.ToString(), Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets", payload);
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.BadRequest), response.ToString());
         }
 
         [Fact]
@@ -229,6 +249,17 @@ namespace Nexpo.Tests.Controllers
 
             var response = await client.DeleteAsync("api/tickets/-22");
             Assert.True(response.StatusCode.Equals(HttpStatusCode.NotFound), response.ToString());
+        }
+
+        [Fact]
+        public async Task DeleteTicketCloseToEvent()
+        {
+            var application = new WebApplicationFactory<Nexpo.Program>();
+            var client = application.CreateClient();
+            var token = await Login("student2", client);
+
+            var response = await client.DeleteAsync("api/tickets/-8");
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.BadRequest), response.ToString());
         }
 
         [Fact]

--- a/Nexpo/Controllers/EventsController.cs
+++ b/Nexpo/Controllers/EventsController.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Nexpo.DTO;
-using Nexpo.Helpers;
 using Nexpo.Models;
 using Nexpo.Repositories;
 
@@ -141,22 +137,27 @@ namespace Nexpo.Controllers
         [ProducesResponseType(typeof(Event), StatusCodes.Status200OK)]
         public async Task<ActionResult> AddNewEvent(AddEventDto dto)
         {
-
-            var even = new Event
+            DateTime temp;
+            if(DateTime.TryParse(dto.Date, out temp) && DateTime.TryParse(dto.Start, out temp) && DateTime.TryParse(dto.End, out temp))
             {
-                Name = dto.Name,
-                Description = dto.Description,
-                Date = dto.Date,
-                Start = dto.Start,
-                End = dto.End,
-                Location = dto.Location,
-                Host = dto.Host,
-                Language = dto.Language,
-                Capacity = dto.Capacity
-            };
-            await _eventRepo.Add(even);
+                var even = new Event
+                {
+                    Name = dto.Name,
+                    Description = dto.Description,
+                    Date = dto.Date,
+                    Start = dto.Start,
+                    End = dto.End,
+                    Location = dto.Location,
+                    Host = dto.Host,
+                    Language = dto.Language,
+                    Capacity = dto.Capacity
+                };
+                await _eventRepo.Add(even);
 
-            return Ok(even);
+                return Ok(even);
+            }
+            
+            return BadRequest();
         }
     }
 

--- a/Nexpo/Controllers/TicketsController.cs
+++ b/Nexpo/Controllers/TicketsController.cs
@@ -56,6 +56,12 @@ namespace Nexpo.Controllers
                 return NotFound();
             }
 
+            DateTime startTime = DateTime.Parse(e.Start);
+            if ((DateTime.Parse(e.Date).AddHours(startTime.Hour -12).AddMinutes(startTime.Minute) - DateTime.Now).TotalHours < 48) 
+            {
+                return BadRequest();
+            }
+
             // Only allow a user to register once
             var userId = HttpContext.User.GetId();
             if (await _ticketRepo.TicketExists(dto.EventId, userId))
@@ -155,6 +161,13 @@ namespace Nexpo.Controllers
 
             if(userRole != Role.Administrator)
             {
+                var e = await _eventRepo.Get(ticket.EventId);
+                DateTime startTime = DateTime.Parse(e.Start);
+                if ((DateTime.Parse(e.Date).AddHours(startTime.Hour - 12).AddMinutes(startTime.Minute) - DateTime.Now).TotalHours < 48)
+                {
+                    return BadRequest();
+                }
+
                 if (ticket.UserId != userId || ticket.isConsumed)
                 {
                     return Forbid();

--- a/Nexpo/Controllers/TicketsController.cs
+++ b/Nexpo/Controllers/TicketsController.cs
@@ -46,7 +46,7 @@ namespace Nexpo.Controllers
         /// Create a new ticket to an event
         /// </summary>
         [HttpPost]
-        [Authorize]
+        [Authorize(Roles = nameof(Role.Student) + "," + nameof(Role.CompanyRepresentative))]
         [ProducesResponseType(typeof(Ticket), StatusCodes.Status201Created)]
         public async Task<ActionResult> PostTicket(CreateTicketDto dto)
         {
@@ -82,6 +82,39 @@ namespace Nexpo.Controllers
 
             return CreatedAtAction(nameof(GetTicket), new { id = ticket.Id }, ticket);
         }
+
+        /// <summary>
+        /// Create new ticket as admin to an event. Ignores capacity and startTime
+        /// </summary>
+        [HttpPost]
+        [Route("add")]
+        [Authorize(Roles = nameof(Role.Administrator))]
+        [ProducesResponseType(typeof(Ticket), StatusCodes.Status201Created)]
+        public async Task<ActionResult> PostTicketAdmin(CreateTicketAdminDto dto)
+        {
+            var e = await _eventRepo.Get(dto.EventId);
+            if (e == null)
+            {
+                return NotFound();
+            }
+
+            // Only allow a user to register once
+            if (await _ticketRepo.TicketExists(dto.EventId, dto.UserId))
+            {
+                return Conflict();
+            }
+
+            var ticket = new Ticket
+            {
+                PhotoOk = dto.PhotoOk,
+                EventId = dto.EventId,
+                UserId = dto.UserId,
+            };
+
+            await _ticketRepo.AddAdmin(ticket);
+
+            return CreatedAtAction(nameof(GetTicket), new { id = ticket.Id }, ticket);
+        } 
 
         /// <summary>
         /// Update isConsumed on a ticket

--- a/Nexpo/DTO/CreateTicketAdminDto.cs
+++ b/Nexpo/DTO/CreateTicketAdminDto.cs
@@ -1,12 +1,15 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿
+using System.ComponentModel.DataAnnotations;
 
 namespace Nexpo.DTO
 {
-    public class CreateTicketDto
+    public class CreateTicketAdminDto
     {
         [Required]
         public int EventId { get; set; }
         [Required]
         public bool PhotoOk { get; set; }
+        [Required]
+        public int UserId { get; set; }
     }
 }

--- a/Nexpo/Models/ApplicationDbContext.cs
+++ b/Nexpo/Models/ApplicationDbContext.cs
@@ -81,11 +81,12 @@ namespace Nexpo.Models
             SaveChanges();
 
             // Events
-            var event1 = new Event { Id = -1, Name = "Breakfast Mingle", Description = "Breakfast with SEB", Date = "2021-11-12", Start = "08:15", End = "10:00", Host = "SEB", Location = "Cornelis", Language = "Swedish", Capacity = 30 };
-            var event2 = new Event { Id = -2, Name = "Bounce with Uber", Description = "Day event at Bounce with Uber", Date = "2021-11-13", Start = "09:00", End = "16:00", Host = "Uber", Location = "Bounce Malmö", Language = "English", Capacity = 20 };
-            var event3 = new Event { Id = -3, Name = "CV Workshop with Randstad", Description = "Make your CV look professional with the help of Randstad", Date = "2021-11-14", Start = "13:30", End = "15:00", Host = "Randstad", Location = "E:A", Language = "Swedish", Capacity = 3 };
-            var event4 = new Event { Id = -4, Name = "Inspirational lunch lecture", Description = "Get inspired and expand your horizons", Date = "2021-11-15", Start = "12:15", End = "13:00", Host = "SYV", Location = "MA:3", Language = "Swedish", Capacity = 2 };
-            Events.AddRange(event1, event2, event3, event4);
+            var event1 = new Event { Id = -1, Name = "Breakfast Mingle", Description = "Breakfast with SEB", Date = "2022-11-12", Start = "08:15", End = "10:00", Host = "SEB", Location = "Cornelis", Language = "Swedish", Capacity = 30 };
+            var event2 = new Event { Id = -2, Name = "Bounce with Uber", Description = "Day event at Bounce with Uber", Date = "2022-11-13", Start = "09:00", End = "16:00", Host = "Uber", Location = "Bounce Malmö", Language = "English", Capacity = 20 };
+            var event3 = new Event { Id = -3, Name = "CV Workshop with Randstad", Description = "Make your CV look professional with the help of Randstad", Date = "2022-11-14", Start = "13:30", End = "15:00", Host = "Randstad", Location = "E:A", Language = "Swedish", Capacity = 3 };
+            var event4 = new Event { Id = -4, Name = "Inspirational lunch lecture", Description = "Get inspired and expand your horizons", Date = "2022-11-15", Start = "12:15", End = "13:00", Host = "SYV", Location = "MA:3", Language = "Swedish", Capacity = 2 };
+            var event5 = new Event { Id = -5, Name = "Pick apples with Apple", Description = "An apple a day keeps the doctor away", Date = DateTime.Now.AddHours(47).ToString(), Start = "12:15", End = "13:00", Host = "Apple", Location = "M:B", Language = "English", Capacity = 200};
+            Events.AddRange(event1, event2, event3, event4, event5);
             SaveChanges();
 
             // Tickets
@@ -96,7 +97,8 @@ namespace Nexpo.Models
             var ticket5 = new Ticket { Id = -5, Code = Guid.NewGuid(), PhotoOk = true, EventId = event4.Id.Value, UserId = user3.Id.Value };
             var ticket6 = new Ticket { Id = -6, Code = Guid.NewGuid(), PhotoOk = true, EventId = event4.Id.Value, UserId = user4.Id.Value };
             var ticket7 = new Ticket { Id = -7, Code = Guid.NewGuid(), PhotoOk = true, EventId = event1.Id.Value, UserId = user4.Id.Value };
-            Tickets.AddRange(ticket1, ticket2, ticket3, ticket4, ticket5, ticket6, ticket7);
+            var ticket8 = new Ticket { Id = -8, Code = Guid.NewGuid(), PhotoOk = true, EventId = event5.Id.Value, UserId = user3.Id.Value };
+            Tickets.AddRange(ticket1, ticket2, ticket3, ticket4, ticket5, ticket6, ticket7, ticket8);
             SaveChanges();
 
             // StudentSessionTimeslots

--- a/Nexpo/Repositories/TicketRepository.cs
+++ b/Nexpo/Repositories/TicketRepository.cs
@@ -15,6 +15,7 @@ namespace Nexpo.Repositories
         public Task<Ticket> Get(int id);
         public Task<Ticket> GetByCode(Guid code);
         public Task<bool> Add(Ticket ticket);
+        public Task AddAdmin(Ticket ticket);
         public Task Update(Ticket ticket);
         public Task Remove(Ticket ticket);
 
@@ -65,7 +66,7 @@ namespace Nexpo.Repositories
                 var _event = await _eventRepo.Get(ticket.EventId);
                 
                 // Don't add ticket if limit is reached
-                if (_event.TicketCount == _event.Capacity) {
+                if (_event.TicketCount >= _event.Capacity) {
                     return false;
                 }
                 
@@ -74,6 +75,12 @@ namespace Nexpo.Repositories
                 dbContextTransaction.Commit();
                 return true;
             }
+        }
+
+        public async Task AddAdmin(Ticket ticket)
+        {
+            _context.Tickets.Add(ticket);
+            await _context.SaveChangesAsync();
         }
 
         public async Task Update(Ticket ticket)


### PR DESCRIPTION
Changelog: 
* Added new Http-request POST in TicketController with route `/add` for admins where the capacity and hours left to event is ignored. 
* Added `AddAdmin` in TicketRepository that ignores the trigger defined in the `Add`
* Added CreateTicketAdminDto
* Updated and added tests for new behaviour

NOTE: This PR contains the changes made in #105 