### PR TITLE
Ticket via mail

### DIFF
--- a/Nexpo.Tests/Controllers/TicketsControllerTest.cs
+++ b/Nexpo.Tests/Controllers/TicketsControllerTest.cs
@@ -820,6 +820,8 @@ namespace Nexpo.Tests.Controllers
             var response = await client.PostAsync("api/tickets/send", payload);
 
             Assert.True(response.StatusCode.Equals(HttpStatusCode.OK),"Wrong status code. Expected: OK. Received: " + response.StatusCode.ToString());
+
+            
         }
 
         [Fact]
@@ -957,6 +959,6 @@ namespace Nexpo.Tests.Controllers
 
             Assert.True(response.StatusCode.Equals(HttpStatusCode.Unauthorized),"Wrong status code. Expected: Unauthorized. Received: " + response.StatusCode.ToString());
         }
-        
+
     } 
 }

--- a/Nexpo.Tests/Controllers/TicketsControllerTest.cs
+++ b/Nexpo.Tests/Controllers/TicketsControllerTest.cs
@@ -802,5 +802,55 @@ namespace Nexpo.Tests.Controllers
             Assert.True(oldEventId == ticket.EventId, "Wrong EventId. Expected: " + oldEventId.ToString() + " Received: " + ticket.EventId.ToString());
             Assert.True(oldUserId == ticket.UserId, "Wrong UserId. Expected: " + oldUserId.ToString() + " Received: " + ticket.UserId.ToString());
         } 
+
+        [Fact]
+        public async Task SendTicketViaEmailAdmin()
+        {
+            
+        }
+
+        [Fact]
+        public async Task SendTicketViaEmailNotLoggedIn()
+        {
+            
+        }
+
+        [Fact]
+        public async Task SendTicketViaEmailNotAdmin()
+        {
+            var client =  await TestUtils.Login("student1");
+
+            var sendTickerViaMailDTO = new SendTickerViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",
+                eventId = -1
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.Forbidden),"Wrong status code. Expected: Forbidden. Received: " + response.StatusCode.ToString());
+            
+        }
+
+        [Fact]
+        public async Task sendTicketViaEmailEventNotFound(){
+            var client =  await TestUtils.Login("admin");
+
+            var sendTickerViaMailDTO = new SendTickerViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",
+                eventId = -100
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.NotFound),"Wrong status code. Expected: NotFound. Received: " + response.StatusCode.ToString());
+
+        }
+            
     } 
 }

--- a/Nexpo.Tests/Controllers/TicketsControllerTest.cs
+++ b/Nexpo.Tests/Controllers/TicketsControllerTest.cs
@@ -806,13 +806,42 @@ namespace Nexpo.Tests.Controllers
         [Fact]
         public async Task SendTicketViaEmailAdmin()
         {
-            
+            var client =  await TestUtils.Login("admin");
+
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",
+                eventId = -1,
+                numberOfTickets = 1
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.OK),"Wrong status code. Expected: OK. Received: " + response.StatusCode.ToString());
         }
 
         [Fact]
         public async Task SendTicketViaEmailNotLoggedIn()
         {
-            
+            var application = new WebApplicationFactory<Program>();
+            var client = application.CreateClient();
+
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",
+                eventId = -1,
+                numberOfTickets = 1
+
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.Unauthorized),"Wrong status code. Expected: Unauthorized. Received: " + response.StatusCode.ToString());
         }
 
         [Fact]
@@ -820,10 +849,12 @@ namespace Nexpo.Tests.Controllers
         {
             var client =  await TestUtils.Login("student1");
 
-            var sendTickerViaMailDTO = new SendTickerViaMailDTO
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
             {
                 mail = "test.testsson@gmail.com",
-                eventId = -1
+                eventId = -1,
+                numberOfTickets = 1
+                
             };
 
             var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
@@ -838,10 +869,11 @@ namespace Nexpo.Tests.Controllers
         public async Task sendTicketViaEmailEventNotFound(){
             var client =  await TestUtils.Login("admin");
 
-            var sendTickerViaMailDTO = new SendTickerViaMailDTO
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
             {
                 mail = "test.testsson@gmail.com",
-                eventId = -100
+                eventId = -100,
+                numberOfTickets = 1
             };
 
             var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
@@ -851,6 +883,80 @@ namespace Nexpo.Tests.Controllers
             Assert.True(response.StatusCode.Equals(HttpStatusCode.NotFound),"Wrong status code. Expected: NotFound. Received: " + response.StatusCode.ToString());
 
         }
-            
+
+        [Fact]
+        public async Task sendTicketViaEmailLessThanOneTicket(){
+            var client =  await TestUtils.Login("admin");
+
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",
+                eventId = -1,
+                numberOfTickets = 0
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.BadRequest),"Wrong status code. Expected: BadRequest. Received: " + response.StatusCode.ToString());
+        }
+
+        [Fact]
+        public async Task sendTicketViaEmailSeveralTickets(){
+            var client =  await TestUtils.Login("admin");
+
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",
+                eventId = -1,
+                numberOfTickets = 2
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.OK),"Wrong status code. Expected: OK. Received: " + response.StatusCode.ToString());
+        }
+
+        [Fact]
+        public async Task sendTicketViaEmailSeveralTicketsNonAdmin(){
+            var client =  await TestUtils.Login("student1");
+
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",
+                eventId = -1,
+                numberOfTickets = 2
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.Forbidden),"Wrong status code. Expected: Forbidden. Received: " + response.StatusCode.ToString());
+
+        }
+
+        [Fact]
+        public async Task sendTicketViaEmailSeveralTicketsNonLoggedIn(){
+            var application = new WebApplicationFactory<Program>();
+            var client = application.CreateClient();
+
+            var sendTickerViaMailDTO = new SendTicketViaMailDTO
+            {
+                mail = "test.testsson@gmail.com",   
+                eventId = -1,
+                numberOfTickets = 2
+            };
+
+            var json = JsonConvert.SerializeObject(sendTickerViaMailDTO);
+            var payload = new StringContent(json, UnicodeEncoding.UTF8, "application/json");
+            var response = await client.PostAsync("api/tickets/send", payload);
+
+            Assert.True(response.StatusCode.Equals(HttpStatusCode.Unauthorized),"Wrong status code. Expected: Unauthorized. Received: " + response.StatusCode.ToString());
+        }
+        
     } 
 }

--- a/Nexpo/Controllers/Events/TicketsController.cs
+++ b/Nexpo/Controllers/Events/TicketsController.cs
@@ -298,7 +298,7 @@ namespace Nexpo.Controllers
                 UserId = -1,
             };
 
-            _ = _emailService.SendTicketAsQRViaEmail(DTO.mail, DTO.QRCode, _event);
+            _ = _emailService.SendTicketAsQRViaEmail(DTO.mail, ticket.Code, _event);
             return Ok();
         }
     }

--- a/Nexpo/Controllers/Events/TicketsController.cs
+++ b/Nexpo/Controllers/Events/TicketsController.cs
@@ -283,7 +283,7 @@ namespace Nexpo.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public async Task<ActionResult> SendTicketToMailAsync(SendTickerViaMailDTO DTO)
         {
-            var eventId = DTO.EventId;
+            var eventId = DTO.eventId;
 
             var _event = await _eventRepo.Get(eventId);
             if (_event == null)

--- a/Nexpo/Controllers/Events/TicketsController.cs
+++ b/Nexpo/Controllers/Events/TicketsController.cs
@@ -274,13 +274,11 @@ namespace Nexpo.Controllers
             return NoContent();
         }
 
-
-
         /// <summary>
-        /// Send many QR code interpretations of the ticket(s) to a event to mail
+        /// Send many QR code interpretations of the tickets to a event to mail
         /// </summary>
         [HttpPost]
-        [Route("sendMany")]
+        [Route("send")]
         [Authorize(Roles = nameof(Role.Administrator))]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public async Task<ActionResult> SendManyTicketsToMailAsync(SendTicketViaMailDTO DTO)

--- a/Nexpo/Controllers/Events/TicketsController.cs
+++ b/Nexpo/Controllers/Events/TicketsController.cs
@@ -31,6 +31,7 @@ namespace Nexpo.Controllers
             _ticketRepo = iTicketRepo;
             _eventRepo  = iEventRepo;
             _userRepo   = iUserRepo;
+            _emailService = iEmailService;
         }
 
         /// <summary>

--- a/Nexpo/Controllers/Events/TicketsController.cs
+++ b/Nexpo/Controllers/Events/TicketsController.cs
@@ -274,14 +274,16 @@ namespace Nexpo.Controllers
             return NoContent();
         }
 
+
+
         /// <summary>
-        /// Send a QR code interpretation of the ticket to mail
+        /// Send many QR code interpretations of the ticket(s) to a event to mail
         /// </summary>
         [HttpPost]
-        [Route("send")]
+        [Route("sendMany")]
         [Authorize(Roles = nameof(Role.Administrator))]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public async Task<ActionResult> SendTicketToMailAsync(SendTickerViaMailDTO DTO)
+        public async Task<ActionResult> SendManyTicketsToMailAsync(SendTicketViaMailDTO DTO)
         {
             var eventId = DTO.eventId;
 
@@ -291,16 +293,46 @@ namespace Nexpo.Controllers
                 return NotFound();
             }
 
-            var ticket = new Ticket
+            if (DTO.numberOfTickets <= 0)
             {
-                PhotoOk = true,
-                EventId = eventId,
-                UserId = -1,
-            };
+                return BadRequest();
+            }
+            else if (DTO.numberOfTickets == 1)
+            {
+                var ticket = new Ticket
+                {
+                    PhotoOk = true,
+                    EventId = eventId,
+                    UserId = -1,
+                };
 
-            _ = _emailService.SendTicketAsQRViaEmail(DTO.mail, ticket.Code, _event);
-            return Ok();
+                _ = _emailService.SendTicketAsQRViaEmail(DTO.mail, ticket.Code, _event);
+                return Ok();
+
+            }
+            else {
+                var tickets = new List<Ticket>();
+
+                for (int i = 0; i < DTO.numberOfTickets; i++)
+                {
+                    var ticket = new Ticket
+                    {
+                        PhotoOk = true,
+                        EventId = eventId,
+                        UserId = -1,
+                    };
+
+                    tickets.Add(ticket);
+                    
+                }
+                _ = _emailService.SendTicketAsQRViaEmail(DTO.mail, tickets, _event);
+
+                return Ok();
+            }
+
+            
         }
+
     }
 }
 

--- a/Nexpo/DTO/Events/SendTickerViaMailDTO.cs
+++ b/Nexpo/DTO/Events/SendTickerViaMailDTO.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+using Nexpo.Models;
+
+namespace Nexpo.DTO
+{
+    /// <summary>
+    /// DTO for sending a ticket via mail
+    /// </summary>
+    public class SendTickerViaMailDTO
+    {
+        [Required]
+        public string mail { get; set; }
+
+        [Required]
+        public string QRCode { get; set; }
+
+        [Required]
+        public int EventId { get; set; }
+    }
+}

--- a/Nexpo/DTO/Events/SendTickerViaMailDTO.cs
+++ b/Nexpo/DTO/Events/SendTickerViaMailDTO.cs
@@ -12,9 +12,6 @@ namespace Nexpo.DTO
         public string mail { get; set; }
 
         [Required]
-        public string QRCode { get; set; }
-
-        [Required]
         public int EventId { get; set; }
     }
 }

--- a/Nexpo/DTO/Events/SendTickerViaMailDTO.cs
+++ b/Nexpo/DTO/Events/SendTickerViaMailDTO.cs
@@ -12,6 +12,6 @@ namespace Nexpo.DTO
         public string mail { get; set; }
 
         [Required]
-        public int EventId { get; set; }
+        public int eventId { get; set; }
     }
 }

--- a/Nexpo/DTO/Events/SendTicketViaMailDTO.cs
+++ b/Nexpo/DTO/Events/SendTicketViaMailDTO.cs
@@ -6,12 +6,16 @@ namespace Nexpo.DTO
     /// <summary>
     /// DTO for sending a ticket via mail
     /// </summary>
-    public class SendTickerViaMailDTO
+    public class SendTicketViaMailDTO
     {
         [Required]
         public string mail { get; set; }
 
         [Required]
         public int eventId { get; set; }
+
+        [Required]
+        public int numberOfTickets { get; set; }
+
     }
 }

--- a/Nexpo/Services/EmailService.cs
+++ b/Nexpo/Services/EmailService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using static Nexpo.DTO.FinalizeSignUpDTO;
 
+
 namespace Nexpo.Services
 {
     public abstract class IEmailService
@@ -71,7 +72,7 @@ namespace Nexpo.Services
             return SendEmail(user.Email, "Reset your password", content, content);
         }
 
-        public Task SendTicketAsQRViaEmail(string targetMail, string qrCode, Event _event)
+        public Task SendTicketAsQRViaEmail(string targetMail, Guid ticketId, Event _event)
         {
             var name = _event.Name;
             var location = _event.Location;
@@ -81,9 +82,11 @@ namespace Nexpo.Services
             var start = _event.Start;
             var end = _event.End;
 
+            string qrImage = "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=" + ticketId;
+
             var content = $"You have been invited to: {name}, at {location}, on {date} between {start} and {end}.<br><br>" +
                 $"Please show the QR-code below at the entrance to get in.<br><br>" +
-                $"<img src=\"{qrCode}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
+                $"<img src=\"{qrImage}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
 
             return SendEmail(targetMail, $"Arkad Ticket: {name}", content, content);
 

--- a/Nexpo/Services/EmailService.cs
+++ b/Nexpo/Services/EmailService.cs
@@ -70,6 +70,26 @@ namespace Nexpo.Services
             var content = $"Reset your password by following this link: {baseUrl}/reset_password/{tokenString} The link is valid for an hour.";
             return SendEmail(user.Email, "Reset your password", content, content);
         }
+
+        public Task SendTicketAsQRViaEmail(string targetMail, string qrCode, Event _event)
+        {
+            var name = _event.Name;
+            var location = _event.Location;
+            var host = _event.Host;
+
+            var date = _event.Date;
+            var start = _event.Start;
+            var end = _event.End;
+
+            var content = $"You have been invited to: {name}, at {location}, on {date} between {start} and {end}.<br><br>" +
+                $"Please show the QR-code below at the entrance to get in.<br><br>" +
+                $"<img src=\"{qrCode}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
+
+            return SendEmail(targetMail, $"Arkad Ticket: {name}", content, content);
+
+
+
+        }
     }
 
     public class EmailService : IEmailService

--- a/Nexpo/Services/EmailService.cs
+++ b/Nexpo/Services/EmailService.cs
@@ -93,7 +93,7 @@ namespace Nexpo.Services
 
         }
 
-        public Task SendTicketAsQRViaEmail(string mail, List<Ticket> tickets, Event _event)
+        public Task SendTicketAsQRViaEmail(string targetMail, List<Ticket> tickets, Event _event)
         {
             var name = _event.Name;
             var location = _event.Location;
@@ -110,10 +110,10 @@ namespace Nexpo.Services
 
             foreach (var ticket in tickets)
             {
-                content += $"<img src=\"{qrImage}{ticket.Id}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
+                content += $"<img src=\"{qrImage}{ticket.Code}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
             }
 
-            return SendEmail(mail, $"Arkad Tickets for {name}", content, content);
+            return SendEmail(targetMail, $"Arkad Tickets for {name}", content, content);
         }
         
     }

--- a/Nexpo/Services/EmailService.cs
+++ b/Nexpo/Services/EmailService.cs
@@ -86,8 +86,10 @@ namespace Nexpo.Services
             string qrImage = "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=" + ticketId;
 
             var content = $"You have been invited to: {name}, at {location}, on {date} between {start} and {end}.<br><br>" +
-                $"Please show the QR-code below at the entrance to get in.<br><br>" +
-                $"<img src=\"{qrImage}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
+                $"Please show the QR-code below at the entrance to get in.<br><br>" + qrImage;
+            //var content = $"You have been invited to: {name}, at {location}, on {date} between {start} and {end}.<br><br>" +
+            //    $"Please show the QR-code below at the entrance to get in.<br><br>" +
+            //    $"<img src=\"{qrImage}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
 
             return SendEmail(targetMail, $"Arkad Ticket for {name}", content, content);
 
@@ -112,7 +114,8 @@ namespace Nexpo.Services
 
             foreach (var ticket in tickets)
             {
-                content += $"<img src=\"{qrImage}{ticket.Code}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
+                content += qrImage+ticket.Code+"<br><br>";
+                //content += $"<img src=\"{qrImage}{ticket.Code}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
             }
 
             return SendEmail(targetMail, $"Arkad Tickets for {name}", content, content);

--- a/Nexpo/Services/EmailService.cs
+++ b/Nexpo/Services/EmailService.cs
@@ -3,6 +3,7 @@ using Nexpo.Models;
 using SendGrid;
 using SendGrid.Helpers.Mail;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using static Nexpo.DTO.FinalizeSignUpDTO;
 
@@ -88,11 +89,33 @@ namespace Nexpo.Services
                 $"Please show the QR-code below at the entrance to get in.<br><br>" +
                 $"<img src=\"{qrImage}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
 
-            return SendEmail(targetMail, $"Arkad Ticket: {name}", content, content);
-
-
+            return SendEmail(targetMail, $"Arkad Ticket for {name}", content, content);
 
         }
+
+        public Task SendTicketAsQRViaEmail(string mail, List<Ticket> tickets, Event _event)
+        {
+            var name = _event.Name;
+            var location = _event.Location;
+            var host = _event.Host;
+
+            var date = _event.Date;
+            var start = _event.Start;
+            var end = _event.End;
+
+            string qrImage = "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=";
+
+            var content = $"You and your collegues have been invited to: {name}, at {location}, on {date} between {start} and {end}.<br><br>" +
+                $"Please show the QR-codes below at the entrance to get in.<br><br>";
+
+            foreach (var ticket in tickets)
+            {
+                content += $"<img src=\"{qrImage}{ticket.Id}\" alt=\"QR-code\" width=\"300\" height=\"300\">";
+            }
+
+            return SendEmail(mail, $"Arkad Tickets for {name}", content, content);
+        }
+        
     }
 
     public class EmailService : IEmailService

--- a/Nexpo/Services/EmailService.cs
+++ b/Nexpo/Services/EmailService.cs
@@ -103,9 +103,11 @@ namespace Nexpo.Services
             var start = _event.Start;
             var end = _event.End;
 
+            var numberOfTickets = tickets.Count;
+
             string qrImage = "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=";
 
-            var content = $"You and your collegues have been invited to: {name}, at {location}, on {date} between {start} and {end}.<br><br>" +
+            var content = $"You and your {numberOfTickets-1} collegue(s) have been invited to: {name}, at {location}, on {date} between {start} and {end}.<br><br>" +
                 $"Please show the QR-codes below at the entrance to get in.<br><br>";
 
             foreach (var ticket in tickets)

--- a/Nexpo/Startup.cs
+++ b/Nexpo/Startup.cs
@@ -69,7 +69,7 @@ namespace Nexpo
             services.AddScoped<IStudentSessionApplicationRepository, StudentSessionApplicationRepository>();
             services.AddScoped<IContactRepository, ContactRepository>();
             services.AddScoped<IFAQRepository, FAQRepository>();
-
+            
             services.AddScoped<PasswordService, PasswordService>();
             services.AddScoped<TokenService, TokenService>();
             services.AddScoped<FileService, FileService>();


### PR DESCRIPTION
This is an implementation of an endpoint that covers the card "Skicka en ticket via mail". Due to companies disliking using the app, the plan is to send tickets to them via mail, hence this is an endpoint in the backend that covers this functionality. The choice to send a QR code as a link, as not as a image, was done mainly due to it lowering the chance of detecting of mail incorrectly detecting the mail as spam.